### PR TITLE
add skipWhileList to Parser

### DIFF
--- a/Z/Data/Parser.hs
+++ b/Z/Data/Parser.hs
@@ -40,7 +40,7 @@ module Z.Data.Parser
     -- * More parsers
   , scan, scanChunks, peekMaybe, peek, satisfy, satisfyWith
   , anyWord8, word8, char8, anyChar8, anyCharUTF8, charUTF8, char7, anyChar7
-  , skipWord8, endOfLine, skip, skipWhile, skipSpaces
+  , skipWord8, endOfLine, skip, skipWhile, skipWhileList, skipSpaces
   , take, takeN, takeTill, takeWhile, takeWhile1, takeRemaining, bytes, bytesCI
   , text
     -- * Numeric parsers

--- a/Z/Data/Parser/Base.hs
+++ b/Z/Data/Parser/Base.hs
@@ -29,7 +29,7 @@ module Z.Data.Parser.Base
     -- * More parsers
   , scan, scanChunks, peekMaybe, peek, satisfy, satisfyWith
   , anyWord8, word8, char8, anyChar8, anyCharUTF8, charUTF8, char7, anyChar7
-  , skipWord8, endOfLine, skip, skipWhile, skipSpaces
+  , skipWord8, endOfLine, skip, skipWhile, skipWhileList, skipSpaces
   , take, takeN, takeTill, takeWhile, takeWhile1, takeRemaining, bytes, bytesCI
   , text
     -- * Error reporting
@@ -669,6 +669,11 @@ skipWhile p =
                     let !rest = V.dropWhile p inp
                     in if V.null rest then Partial (go s) else k s () rest
         in go s0
+
+-- | Skip past input for as long as the byte is not an element of a given list.
+skipWhileList :: [Word8] -> Parser ()
+{-# INLINE skipWhileList #-}
+skipWhileList xs = skipWhile (`notElem` xs)
 
 -- | Skip over white space using 'isSpace'.
 --


### PR DESCRIPTION
In building the library [Z-Botan](https://github.com/ZHaskell/z-botan) we saw ([there](https://github.com/alissa-tung/z-botan/commit/67a7f5b86dc6cf8913d6f6527705079bffe2fc98)) a common pattern of boilerplate like
```haskell
      P.skipWhile $ \c ->
        c /= LETTER_S -- Secret
          && c /= LETTER_B -- Basepoint
          && c /= LETTER_O -- Out
      c <- P.peekMaybe
```
and it can be solved by
```haskell
    pa acc = do
      P.skipWhile (`notElem` [LETTER_P, LETTER_P, LETTER_Q, HASH])
      c <- P.peek
```
.