### PR TITLE
use FNV-1a alternate hashing algo

### DIFF
--- a/cbits/bytes.c
+++ b/cbits/bytes.c
@@ -53,19 +53,21 @@ HsInt hs_memrchr(uint8_t *a, HsInt aoff, uint8_t c, HsInt n) {
     else return (p - a);
 }
 
-/* FNV-1 hash
+/* FNV-1a hash
  *
- * The FNV-1 hash description: http://isthe.com/chongo/tech/comp/fnv/
- * The FNV-1 hash is public domain: http://isthe.com/chongo/tech/comp/fnv/#public_domain
+ * The FNV-1a hash description: http://isthe.com/chongo/tech/comp/fnv/#FNV-1a
+ * The FNV hash is public domain: http://isthe.com/chongo/tech/comp/fnv/#public_domain
  *
  * The original version from hashable use long type which doesn't match 'Int' in haskell and
  * cause problems on window, here we use HsInt.
+ *
+ * Using FNV-1a because it has better avalanche properties compared to the FNV original version.
  */
 HsInt hs_fnv_hash_addr(const unsigned char *str, HsInt len, HsInt salt) {
 
     HsWord hash = salt;
     while (len--) {
-      hash = (hash * 16777619) ^ *str++;
+      hash = (hash ^ *str++) * 16777619;
     }
 
     return hash;


### PR DESCRIPTION
The FNV-1a should have a better avalanche properties compared to FNV-1. It is also suggested by the author in his [website](http://isthe.com/chongo/tech/comp/fnv/#FNV-1a).

However, I am not sure why I can't pass the tests of comparing hash result of `CBytes` and `Bytes`.

May I know how can the team evaluate the performance benchmarks? I think the FNV can be implemented in Haskell using unlifted pointer & int arithmetic operations, therefore eliminating the `unsafeDupableIO`.

I am not sure about the performance impact, maybe someone in the team can share some insights of GHC internals / methods to benchmark things.